### PR TITLE
Use SSL for Heroku Postgres remote connection

### DIFF
--- a/src/main/java/com/example/helloworld/ExampleDatabaseConfiguration.java
+++ b/src/main/java/com/example/helloworld/ExampleDatabaseConfiguration.java
@@ -32,7 +32,8 @@ public class ExampleDatabaseConfiguration implements DatabaseConfiguration {
             URI dbUri = new URI(databaseUrl);
             final String user = dbUri.getUserInfo().split(":")[0];
             final String password = dbUri.getUserInfo().split(":")[1];
-            final String url = "jdbc:postgresql://" + dbUri.getHost() + ':' + dbUri.getPort() + dbUri.getPath();
+			final String url = "jdbc:postgresql://" + dbUri.getHost() + ':' + dbUri.getPort() + dbUri.getPath()
+					+ "?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory";
             databaseConfiguration = new DatabaseConfiguration() {
                 DataSourceFactory dataSourceFactory;
                 @Override


### PR DESCRIPTION
When testing locally using Foreman, it will not connect to Heroku Postgres database without SSL.
This behavior is described in this Heroku's article :
https://devcenter.heroku.com/articles/connecting-to-relational-databases-on-heroku-with-java#connecting-to-a-database-remotely
